### PR TITLE
add xor blending mode attempt 2

### DIFF
--- a/src/cogs/render.py
+++ b/src/cogs/render.py
@@ -336,6 +336,8 @@ class Renderer:
                 b[..., 3] = 1 - b[..., 3]
             c[..., 3] *= b[..., 3]
             c[c[..., 3] == 0] = 0
+        elif mode == "xor":
+            c = a ^ b
         else:
             raise AssertionError(f"Blending mode `{mode}` isn't implemented yet.")
         if keep_alpha:

--- a/src/cogs/render.py
+++ b/src/cogs/render.py
@@ -337,7 +337,13 @@ class Renderer:
             c[..., 3] *= b[..., 3]
             c[c[..., 3] == 0] = 0
         elif mode == "xor":
-            c = a ^ b
+            c = a.copy()
+            c[..., 3] *= (1 - b[..., 3])
+            c[c[..., 3] == 0] = 0
+            d = b.copy()
+            d[..., 3] *= (1 - a[..., 3])
+            d[d[..., 3] == 0] = 0
+            c += d
         else:
             raise AssertionError(f"Blending mode `{mode}` isn't implemented yet.")
         if keep_alpha:

--- a/src/constants.py
+++ b/src/constants.py
@@ -269,7 +269,8 @@ BLENDING_MODES = (
     "mask",
     "dodge",
     "burn",
-    "cut"
+    "cut",
+    "xor"
 )
 
 FILTER_MAX_SIZE = 524288


### PR DESCRIPTION
this version of xor simply cuts out the place where both sprites overlap, instead of bitwise xor'ing the colors
in a sense it's xor'ing the alphas

also i actually tested it this time