### PR TITLE
Add .DS_Store to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ data/levels/new_adv_m/
 data/images/**/*
 target/renders/
 *.gif
+.DS_Store


### PR DESCRIPTION
Ignores a macOS-specific file.
This file is automatically generated by the OS and only really adds unnecessary changes and irrelevant clutter.
It's a folder metadata file, akin to desktop.ini